### PR TITLE
Add parallel Github Actions builds with different PHP versions

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -1,24 +1,41 @@
 name: PHP Test Suite
 
 on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  - push
+  - pull_request
 
 jobs:
-  build:
 
+  test:
     runs-on: ubuntu-latest
-
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: ['7.2', '7.3', '7.4']
+        experimental: [false]
+        include:
+          - php-version: '8.0'
+            experimental: true
+    
+    name: PHP v${{ matrix.php-version }}
+    
     steps:
-    - uses: actions/checkout@v2
 
-    - name: Validate composer.json and composer.lock
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-version }}
+        coverage: pcov
+
+    - name: Validate Composer Files
       run: composer validate --strict
 
-    - name: Install dependencies
-      run: composer install --prefer-dist --no-progress --no-suggest --optimize-autoloader
+    - name: Install Dependencies
+      run: composer install --prefer-dist --no-interaction --no-progress --no-suggest --optimize-autoloader
 
-    - name: Run test suite
-      run: composer test
+    - name: Run Tests
+      run: composer test-coverage

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
-# e2-module
-Helper for creating payments with Paytrail Form Interface (E2)
+# Paytrail E2 module
+
+[![Latest Stable Version](https://poser.pugx.org/paytrail/e2-module/v/stable)](https://packagist.org/packages/paytrail/e2-module)
+![PHP Test Suite](https://github.com/paytrail/e2-module/workflows/PHP%20Test%20Suite/badge.svg)
+[![Total Downloads](https://poser.pugx.org/paytrail/e2-module/downloads)](https://packagist.org/packages/paytrail/e2-module)
+[![License](https://poser.pugx.org/paytrail/e2-module/license)](https://packagist.org/packages/paytrail/e2-module)
+
+> A PHP client library for creating payments with Paytrail Form Interface (E2).
 
 ## Installation
 Install via composer
 
 ```bash
-composer require Paytrail/e2-module
+composer require paytrail/e2-module
 ```
 
 ## Documentation
 
-Paytrail official documentation can be found in [https://docs.paytrail.com](https://docs.paytrail.com)
+Paytrail official documentation can be found [here][docs].
 
-## Examples
+## Usage
 
 ### Payment without customer and product information
 
@@ -31,7 +37,7 @@ echo $e2Payment->getPaymentForm();
 ### Payment widget with customer, product information and custom return urls
 
 Include customer information, discounted product and custom return urls.
-Payment, customer and product properties can be found from [documentation](https://docs.paytrail.com)
+Payment, customer and product properties can be found from [documentation][docs]
 
 ```php
 use Paytrail\E2Module\Merchant;
@@ -89,7 +95,7 @@ After returning from payment, whether success or cancelled, validate return auth
 $isValidPayment = $e2Payment->returnAuthcodeIsValid($_GET);
 ```
 
-You can also send return parameters as array insted of using `$_GET` superglobal.
+You can also send return parameters as array instead of using `$_GET` superglobal.
 If return code is not valid, you can get validation errors.
 
 ```php
@@ -98,6 +104,7 @@ $errorReasons = $e2Payment->getErrors();
 This return array of all error reasons in return authcode validation.
 
 To get status of payment, paid or not.
+
 ```php
 $isPaid = $e2Payment->isPaid($_GET);
 ```
@@ -115,3 +122,5 @@ if (!$isValidPayment) {
 $isPaid = $e2Payment->isPaid($_GET);
 // Code to handle paid/cancelled status for order.
 ```
+
+[docs]: https://docs.paytrail.com

--- a/composer.json
+++ b/composer.json
@@ -19,12 +19,21 @@
             "Paytrail\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Paytrail\\Tests\\": "tests/"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "^8.0",
         "phpunit/php-code-coverage": "^7.0"
     },
     "scripts": {
-        "test": "vendor/bin/phpunit",
-        "test-coverage": "vendor/bin/phpunit --coverage-text --coverage-html test-reports/html --coverage-clover test-reports/clover.xml tests --log-junit test-reports/junit.xml"
-    }
+        "test": [
+            "@composer dump-autoload -o",
+            "vendor/bin/phpunit"
+        ],
+        "test-coverage": "@test --coverage-text --coverage-html test-reports/html"
+    },
+    "prefer-stable": true
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca1c4c38cf94989d2a1ba13835c24e14",
+    "content-hash": "e2b38441dbbcd61048565ae68e68ec88",
     "packages": [],
     "packages-dev": [
         {
@@ -1527,7 +1527,7 @@
     "aliases": [],
     "minimum-stability": "stable",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "php": ">=7.2"


### PR DESCRIPTION
For enhanced quality assurance, this pull request makes the Actions pipeline run against **PHP 7.2, 7.3, 7.4, and 8.0** (experimental, allowed to fail). I am using [a community action](https://github.com/shivammathur/setup-php) for this since no official PHP actions exist to my knowledge.

The step for running unit tests was changed to include coverage calculated with `pcov` which should be faster than `xdebug` and works out of the box with the action above.

Finally, a couple of updates to the README.md showing off some sweet badges that public PHP projects usually ship.

No changes to the library logic were made so we can relax and merge this with one approving review.