### PR TITLE
Fix template path case

### DIFF
--- a/src/E2Module/Template.php
+++ b/src/E2Module/Template.php
@@ -14,7 +14,7 @@ use Paytrail\Exceptions\TemplateException;
  */
 class Template
 {
-    const TEMPLATE_PATH = '/../templates/';
+    const TEMPLATE_PATH = '/../Templates/';
 
     /**
      * Extract data variables from array and render template from template folder, use basename to chroot in template directory.


### PR DESCRIPTION
Fix template path case. The wrong case throws an exception in a case-sensitive filesystem.

## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Fix template path case. Folders are capitalized, but path is in lowercase. Case-sensitive filesystem can't find template file and throws an exception.

## Tests

- [x] Not needed
- [ ] Unit tests added
- [ ] Integration tests added
- [ ] Visual verification done

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
