### PR TITLE
Add getPaymentData() method to allow custom forms

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ echo $e2Payment->addCustomer($customer)
     ->getPaymentWidget();
 ```
 
+### Rendering a custom payment form
+
+```php
+use Paytrail\E2Module\Merchant;
+use Paytrail\E2Module\E2Payment;
+
+$merchant = Merchant::create($merchantId, $merchantSecret);
+$e2Payment = new E2Payment($merchant);
+
+$fields = $e2Payment->addAmount($orderAmount)
+    ->createPayment($orderNumber)
+    ->getPaymentData();
+
+foreach ($fields as $name => $value) {
+    // Your form logic should generate a hidden input field:
+    // <input type="hidden" name="$name", value="$value">
+}
+```
+
+Set form action to `$e2Payment->getPaymentUrl();`.
+
 ### Validating completed payment
 
 After returning from payment, whether success or cancelled, validate return authcode. Same validation applies to notify url.

--- a/src/E2Module/E2Payment.php
+++ b/src/E2Module/E2Payment.php
@@ -188,7 +188,7 @@ class E2Payment
      */
     public function getPaymentForm(string $buttonText = Form::BUTTON_DEFAULT_TEXT, string $formId = Form::DEFAULT_FORM_ID): string
     {
-        return Form::createPaymentForm($this->toArray(), $buttonText, $formId);
+        return Form::createPaymentForm($this->getPaymentData(), $buttonText, $formId);
     }
 
     /**
@@ -201,7 +201,7 @@ class E2Payment
      */
     public function getPaymentWidget(string $buttonText = Form::BUTTON_DEFAULT_TEXT, string $formId = Form::DEFAULT_FORM_ID, ?string $widgetUrl = null): string
     {
-        return Form::createPaymentWidget($this->toArray(), $buttonText, $formId, $widgetUrl);
+        return Form::createPaymentWidget($this->getPaymentData(), $buttonText, $formId, $widgetUrl);
     }
 
     /**
@@ -209,7 +209,7 @@ class E2Payment
      *
      * @return array
      */
-    public function toArray(): array
+    public function getPaymentData(): array
     {
         $this->validator->validatePaymentData($this->paymentData);
         $this->paymentData['AUTHCODE'] = Authcode::calculateAuthCode($this->paymentData, $this->merchant);

--- a/src/E2Module/E2Payment.php
+++ b/src/E2Module/E2Payment.php
@@ -188,10 +188,7 @@ class E2Payment
      */
     public function getPaymentForm(string $buttonText = Form::BUTTON_DEFAULT_TEXT, string $formId = Form::DEFAULT_FORM_ID): string
     {
-        $this->validator->validatePaymentData($this->paymentData);
-        $this->paymentData['AUTHCODE'] = Authcode::calculateAuthCode($this->paymentData, $this->merchant);
-
-        return Form::createPaymentForm($this->paymentData, $buttonText, $formId);
+        return Form::createPaymentForm($this->toArray(), $buttonText, $formId);
     }
 
     /**
@@ -204,10 +201,20 @@ class E2Payment
      */
     public function getPaymentWidget(string $buttonText = Form::BUTTON_DEFAULT_TEXT, string $formId = Form::DEFAULT_FORM_ID, ?string $widgetUrl = null): string
     {
+        return Form::createPaymentWidget($this->toArray(), $buttonText, $formId, $widgetUrl);
+    }
+
+    /**
+     * Get Paytrail payment data as array.
+     *
+     * @return array
+     */
+    public function toArray(): array
+    {
         $this->validator->validatePaymentData($this->paymentData);
         $this->paymentData['AUTHCODE'] = Authcode::calculateAuthCode($this->paymentData, $this->merchant);
 
-        return Form::createPaymentWidget($this->paymentData, $buttonText, $formId, $widgetUrl);
+        return $this->paymentData;
     }
 
     /**

--- a/tests/E2PaymentTest.php
+++ b/tests/E2PaymentTest.php
@@ -137,7 +137,7 @@ class E2PaymentTest extends TestCase
         $this->e2Payment->addCustomer($this->customer);
         $this->e2Payment->createPayment('order-123');
 
-        $data = $this->e2Payment->toArray();
+        $data = $this->e2Payment->getPaymentData();
 
         $this->assertNotEmpty($data);
 

--- a/tests/E2PaymentTest.php
+++ b/tests/E2PaymentTest.php
@@ -131,6 +131,22 @@ class E2PaymentTest extends TestCase
         $this->assertStringContainsString(self::WIDGET_URL, $formData);
     }
 
+    public function testToArray()
+    {
+        $this->e2Payment->addProducts([$this->product]);
+        $this->e2Payment->addCustomer($this->customer);
+        $this->e2Payment->createPayment('order-123');
+
+        $data = $this->e2Payment->toArray();
+
+        $this->assertNotEmpty($data);
+
+        foreach (self::REQUIRED_PAYMENT_DATA as $requiredData) {
+            $this->assertNotEmpty($data[$requiredData]);
+        }
+        $this->assertNotEmpty($data['ITEM_TITLE[0]']);
+    }
+
     public function testDefaultReturnUrlsCanBeOverride()
     {
         $this->e2Payment->addProducts([$this->product]);


### PR DESCRIPTION
## What type of Pull Request is this?

Check all the applicable.

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

At the moment you cannot render forms without using E2Payment::getPaymentForm/Widget() methods, making working with things like form builders/templating engines unnecessary complicated.

## Tests

- [ ] Not needed
- [x] Unit tests added
- [ ] Integration tests added
- [ ] Visual verification done

## Code of Conduct

- [x] I have read and agreed to the [community code of conduct][coc]. The sole intention of this pull request is to improve the project codebase.

[coc]: https://github.com/paytrail/.github/blob/master/CODE_OF_CONDUCT.md
